### PR TITLE
Fix bug and start using master branch for two wrappers

### DIFF
--- a/src/Snakemake/rules/Alignment/bam-split.smk
+++ b/src/Snakemake/rules/Alignment/bam-split.smk
@@ -67,10 +67,8 @@ rule bam_split:
             for chr in utils.extract_chr(config['reference']['ref'] + ".fai")
         ],
     params:
-        extra=lambda wildcards: "-reference -refPrefix '' -stub " + utils.extract_stub(
-            _bam_split_output, _split_separator
-        ),
+        extra="-reference -refPrefix '' -stub " + utils.extract_stub(_bam_split_output, "." + _split_separator),
     singularity:
         config["singularity"].get("bamtools", config["singularity"].get("default", ""))
     wrapper:
-        "file:///projects/wp4/nobackup/workspace/snakemake-wrappers-fork/bio/bamtools/split"
+        "master/bio/bamtools/split"

--- a/src/Snakemake/rules/SNV/mutect2.smk
+++ b/src/Snakemake/rules/SNV/mutect2.smk
@@ -73,6 +73,7 @@ except:
     pass
 
 
+# TODO Maybe add sample name, to handle cases when multiple designs are run in the same analysis?
 rule split_bedfile:
     input:
         config["bed"]["bedfile"],
@@ -81,7 +82,7 @@ rule split_bedfile:
     log:
         "logs/variantCalling/split_bed.{chr}.log",
     shell:
-        "(grep -w {wildcards.chr} {input}  > {output}) &> {log}"
+        "awk '{{if(/^{wildcards.chr}\t/) print($0)}}' {input}  > {output} &> {log}"
 
 
 rule mutect2:
@@ -97,7 +98,7 @@ rule mutect2:
         vcf=temp("mutect2/temp/{sample}.{chr}.mutect2.unfilt.vcf.gz"),
         vcf_tbi=temp("mutect2/temp/{sample}.{chr}.mutect2.unfilt.vcf.gz.tbi"),
     params:
-        extra=lambda wildcards: "--bam-output mutect2/bam/" + wildcards.sample + "." + wildcards.chr + ".indel.bam",
+        extra="",
     threads: 1
     log:
         "logs/variantCalling/mutect2_{sample}.{chr}.log",
@@ -105,7 +106,7 @@ rule mutect2:
         config["singularity"].get("mutect2", config["singularity"].get("default", ""))
     wrapper:
         # "(gatk --java-options '-Xmx4g' Mutect2 -R {input.fasta} -I {input.bam} -L {input.bed} --bam-output {output.bam} -O {output.vcf}) &> {log}"
-        "0.70.0/bio/gatk/mutect"
+        "master/bio/gatk/mutect"
 
 
 rule filterMutect2:

--- a/src/Snakemake/workflow/gms_somatic_workflow.smk
+++ b/src/Snakemake/workflow/gms_somatic_workflow.smk
@@ -7,7 +7,7 @@ def fastq_files(wildcards):
 
 
 fastp_trimming_input = lambda wildcards: fastq_files(wildcards)
-mutect2_output = "mutect2/{sample}.mutect2.fixAF.vcf"
+mutect2_output_vcf = "mutect2/{sample}.mutect2.fixAF.vcf"
 
 
 include: "../rules/Alignment/index_bam.smk"

--- a/src/lib/python/utils.py
+++ b/src/lib/python/utils.py
@@ -6,7 +6,7 @@ def extract_chr(file):
 
 
 def extract_stub(path, sep):
-    parts = path[0].split(sep)
-    if len(parts):
-        raise Exception("Unable to split path: " + path)
+    parts = path.split(sep)
+    if len(parts) <= 1:
+        raise Exception("Unable to split path: " + path + " using separator " + sep)
     return parts[0]


### PR DESCRIPTION
Start using master branch for bam-split and mutect wrappers, until a new release is made. Fix bed-splits that failes if input file doesn't contain the searched string.